### PR TITLE
removed IsPedInAnyBoat check

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -642,10 +642,7 @@ end)
 CreateThread(function()
     while true do
         Wait(0)
-        local player = PlayerPedId()
-        if IsPedInAnyBoat(player) then
-            SetPedResetFlag(player, 364, 1)
-        end
+        Citizen.InvokeNative(0xC1E8A365BF3B29F2, PlayerPedId(), 364, 1) -- SetPedResetFlag / IgnoreDrownAndKillVolumes
     end
 end)
 
@@ -742,7 +739,8 @@ end
 function LoadModel(model)
     RequestModel(model)
     while not HasModelLoaded(model) do
-        Wait(10)
+        RequestModel(model)
+        Wait(100)
     end
 end
 


### PR DESCRIPTION
Removed IsPedInAnyBoat check from thread. Now IgnoreDrownAndKillVolumes will be in effect at all times. Prevents boat from sinking when player leaves the boat in areas affected by the drown and kill volumes.